### PR TITLE
Add pre-deploy scripts to deploy frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a list of examples on how to use the `genezio` tool.
 
 In each project, you can check the installation details inside the corresponding `README` file.
 
-The list of available projects can be found below. 
+The list of available projects can be found below.
  - Javascript:
      - [hello-world](javascript/hello-world)
      - [todo-list](javascript/todo-list)
@@ -13,9 +13,14 @@ The list of available projects can be found below.
      - [cron](javascript/cron)
      - [webhook](javascript/webhook)
      - [blockchain](javascript/blockchain)
+     - [chatgpt-rephrasing](javascript/chatgpt-project)
+     - [stripe-integration](javascript/stripe-js)
  - Typescript
      - [hello-world](typescript/hello-world)
      - [todo-list](typescript/todo-list)
      - [todo-list-angular](typescript/todo-list-angular)
+     - [multiversX](typescript/multiversx)
+ - Swift
+     - [todo-list](swift/todo-list)
 
 For more details, you can check out the [documentation](https://docs.genez.io/genezio-documentation/).

--- a/javascript/blockchain/README.md
+++ b/javascript/blockchain/README.md
@@ -4,6 +4,10 @@ In this example, we have implemented a class that queries periodically using Bla
 
 The class is implemented in the `./server/blockchainServer.js` file.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -16,7 +20,7 @@ The class is implemented in the `./server/blockchainServer.js` file.
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder. This will deploy the code to Genezio infrastructure and it will create the SDK.
+1. Run `genezio deploy --backend` in the `server/` folder. This will deploy the code to Genezio infrastructure and it will create the SDK.
 2. Open a new terminal and run the React app in the `client/` folder.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/javascript/blockchain/server/genezio.yaml
+++ b/javascript/blockchain/server/genezio.yaml
@@ -7,7 +7,9 @@ sdk:
   path: ../client/src/sdk/
 frontend:
   path: ../client/build/
-  subdomain: cyan-light-owl
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: ./blockchainServer.js
     type: jsonrpc

--- a/javascript/cron/README.md
+++ b/javascript/cron/README.md
@@ -8,4 +8,4 @@ Run `genezio local`. This will start a local web server.
 
 ## Deploy the example in the Genezio infrastructure
 
-Run `genezio deploy`.
+Run `genezio deploy --backend`.

--- a/javascript/getting-started/README.md
+++ b/javascript/getting-started/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a TODO application that introduces the user to the Genezio infrastructure.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,7 +18,7 @@ This is an example of a TODO application that introduces the user to the Genezio
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `client/` folder and run `npm start`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/javascript/getting-started/server/genezio.yaml
+++ b/javascript/getting-started/server/genezio.yaml
@@ -1,10 +1,14 @@
 name: getting-started-genezio
 region: eu-central-1
+cloudProvider: aws
 sdk:
   language: js
   options:
     runtime: browser
   path: ../client/src/sdk
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 frontend:
   path: ../client/build
 classes:

--- a/javascript/hello-world/README.md
+++ b/javascript/hello-world/README.md
@@ -4,7 +4,7 @@ In this example, we have a class with two functions that return a welcome messag
 
 The class is implemented in the `./server/hello.js` file.
 
-To deploy and test it run `genezio deploy`. Once the command was successfully executed you can run `node ./client/test-hello-sdk.js`.
+To deploy and test it run `genezio deploy --backend`. Once the command was successfully executed you can run `node ./client/test-hello-sdk.js`.
 
 ## Run the example locally
 
@@ -14,6 +14,6 @@ To deploy and test it run `genezio deploy`. Once the command was successfully ex
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder. This will deploy the code to Genezio infrastructure and it will create the SDK.
+1. Run `genezio deploy --backend` in the `server/` folder. This will deploy the code to Genezio infrastructure and it will create the SDK.
 2. Run `node ./client/test-hello-sdk.js`. Now the script will use the SDK to call the methods that you have previously deployed in the Genezio infrastructure.
 3. You should see the greeting messages.

--- a/javascript/html-example/README.md
+++ b/javascript/html-example/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a TODO application that introduces the user to the Genezio infrastructure with simple HTML and JavaScript, without any framework.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -13,7 +17,7 @@ This is an example of a TODO application that introduces the user to the Genezio
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 
 ## Deploy the frontend in Genezio Infrastructure
 

--- a/javascript/html-example/server/genezio.yaml
+++ b/javascript/html-example/server/genezio.yaml
@@ -7,6 +7,9 @@ sdk:
   path: ../client/sdk
 frontend:
   path: ../client
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install"
 classes:
   - path: ./task.js
     type: jsonrpc

--- a/javascript/stripe-js/README.md
+++ b/javascript/stripe-js/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a simple checkout with Stripe that uses React for the frontend application and Genezio for deploying and developing the backend.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,7 +18,7 @@ This is an example of a simple checkout with Stripe that uses React for the fron
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `client/` folder and run `npm start`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/javascript/stripe-js/server/genezio.yaml
+++ b/javascript/stripe-js/server/genezio.yaml
@@ -8,6 +8,9 @@ sdk:
   path: ./../client/src/sdk/
 frontend:
   path: ./../client/build/
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: StripeHandler.js
     type: jsonrpc

--- a/javascript/todo-list-sql/README.md
+++ b/javascript/todo-list-sql/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a todo application with users, auth and tasks that uses React for the frontend application and Genezio for deploying and developing the backend.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,7 +18,7 @@ This is an example of a todo application with users, auth and tasks that uses Re
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy -backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `client/` folder and run `npm start`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/javascript/todo-list-sql/server/genezio.yaml
+++ b/javascript/todo-list-sql/server/genezio.yaml
@@ -7,6 +7,9 @@ sdk:
   path: ../client/src/sdk
 frontend:
   path: ../client/build
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: ./task.js
     type: jsonrpc

--- a/javascript/todo-list-vue/README.md
+++ b/javascript/todo-list-vue/README.md
@@ -1,6 +1,11 @@
-# Todo Angular App example
+# Todo Vue App example
 
 This is an example of a todo application with users, auth and tasks that uses VueJS for the frontend application and Genezio for deploying and developing the backend.
+
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 
 ## Initialization
 
@@ -14,7 +19,7 @@ This is an example of a todo application with users, auth and tasks that uses Vu
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy -backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the VueJS app by going to the `client/` folder and run `npm run dev`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/javascript/todo-list-vue/client/README.md
+++ b/javascript/todo-list-vue/client/README.md
@@ -1,4 +1,4 @@
-# todo-list-angular-client
+# todo-list-vue-client
 
 > A Vue.js project
 

--- a/javascript/todo-list-vue/server/genezio.yaml
+++ b/javascript/todo-list-vue/server/genezio.yaml
@@ -6,9 +6,11 @@ sdk:
   options:
     runtime: browser
   path: ../client/src/sdk
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 frontend:
   path: ../client/dist
-  subdomain: gold-awful-bear
 classes:
   - path: ./task.js
     type: jsonrpc

--- a/javascript/todo-list/README.md
+++ b/javascript/todo-list/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a todo application with users, auth and tasks that uses React for the frontend application and Genezio for deploying and developing the backend.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,7 +18,7 @@ This is an example of a todo application with users, auth and tasks that uses Re
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `client/` folder and run `npm start`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/javascript/todo-list/server/genezio.yaml
+++ b/javascript/todo-list/server/genezio.yaml
@@ -7,6 +7,9 @@ sdk:
   path: ../client/src/sdk
 frontend:
   path: ../client/build
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: ./task.js
     type: jsonrpc

--- a/typescript/multiversx/README.md
+++ b/typescript/multiversx/README.md
@@ -2,6 +2,10 @@
 
 This is an example of an integration with the MultiversX blockchain. The application queries the balance of an existing account.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,9 +18,10 @@ This is an example of an integration with the MultiversX blockchain. The applica
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `client/` folder and run `npm start`.
 
 ## Deploy the frontend in Genezio Infrastructure
+
 1. Run `npm i && npm run build` in the `client` folder to build the React app.
-2. Run `genezio deploy --frontend` in the `server` folder to deploy the frontend in the Genezio infrastructure.
+2. Run `genezio deploy --frontend` in the `server` folder to deploy the frontend in the genezio infrastructure.

--- a/typescript/multiversx/server/genezio.yaml
+++ b/typescript/multiversx/server/genezio.yaml
@@ -8,7 +8,9 @@ sdk:
   path: ../client/src/sdk
 frontend:
   path: ../client/build
-  subdomain: sapphire-marginal-blackbird
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: ./index.ts
     type: jsonrpc

--- a/typescript/todo-list-angular/README.md
+++ b/typescript/todo-list-angular/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a todo application with users, auth and tasks that uses Angular for the frontend application and Genezio for deploying and developing the backend.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,7 +18,7 @@ This is an example of a todo application with users, auth and tasks that uses An
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the Angular frontend app by going to the `client/` folder and run `ng serve`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/typescript/todo-list-angular/server/genezio.yaml
+++ b/typescript/todo-list-angular/server/genezio.yaml
@@ -7,7 +7,9 @@ sdk:
   path: ../client/src/sdk
 frontend:
   path: ../client/dist/todo-list
-  subdomain: todo-list-angular
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: ./task.ts
     type: jsonrpc

--- a/typescript/todo-list/README.md
+++ b/typescript/todo-list/README.md
@@ -2,6 +2,10 @@
 
 This is an example of a todo application with users, auth and tasks that uses React for the frontend application and Genezio for deploying and developing the backend.
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Initialization
 
 1. Run `npm install` in the `server/` folder to install the dependencies.
@@ -14,7 +18,7 @@ This is an example of a todo application with users, auth and tasks that uses Re
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy --backend` in the `server/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `client/` folder and run `npm start`.
 
 ## Deploy the frontend in Genezio Infrastructure

--- a/typescript/todo-list/client/README.md
+++ b/typescript/todo-list/client/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+Note: `genezio deploy` deploys both backend and frontend. If you want to test this example out-of-the-box by running 1 command, head to the `server` directory and run `genezio deploy`.
+
+If you want to deploy your application step-by-step, follow the guidelines below.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/typescript/todo-list/server/genezio.yaml
+++ b/typescript/todo-list/server/genezio.yaml
@@ -7,6 +7,9 @@ sdk:
   path: ../client/src/sdk
 frontend:
   path: ../client/build
+scripts:
+  preBackendDeploy: "npm install"
+  preFrontendDeploy: "cd ../client && npm install && npm run build"
 classes:
   - path: ./task.ts
     type: jsonrpc


### PR DESCRIPTION
Since we are migrating to 1-command deploy (`genezio deploy` will deploy both backend and frontend). 

For that to be possible out-of-the-box we have to configure the `scripts` field as following for all the examples that are also having frontend:
```
scripts:
  preBackendDeploy: "npm install"
  preFrontendDeploy: "cd ../client && npm install && npm run build"
``` 