### PR TITLE
Remove Fluttertoast from getting started

### DIFF
--- a/dart/getting-started/client/lib/add_task_alert_dialog.dart
+++ b/dart/getting-started/client/lib/add_task_alert_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 
 import 'package:todo_list/sdk/task.dart';
 
@@ -90,25 +89,25 @@ class _AddTaskAlertDialogState extends State<AddTaskAlertDialog> {
             final title = taskNameController.text;
             final url = taskUrlController.text;
             Task.createTask(widget.token, title, url).then((_) {
-              Fluttertoast.showToast(
-                  msg: "Task added successfully",
-                  toastLength: Toast.LENGTH_LONG,
-                  gravity: ToastGravity.BOTTOM,
-                  backgroundColor: Colors.black,
-                  textColor: Colors.white,
-                  fontSize: 14.0);
+              // Create a snackbar to show a message to the user.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Task created'),
+                  backgroundColor: Colors.green,
+                ),
+              );
               Navigator.popAndPushNamed(
                 context,
                 '/',
               );
             }).catchError((error) {
-              Fluttertoast.showToast(
-                  msg: "Update failed: $error",
-                  toastLength: Toast.LENGTH_LONG,
-                  gravity: ToastGravity.SNACKBAR,
-                  backgroundColor: Colors.black,
-                  textColor: Colors.white,
-                  fontSize: 14.0);
+              // Create a snackbar to show a message to the user.
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(error.toString()),
+                  backgroundColor: Colors.red,
+                ),
+              );
             });
           },
           child: const Text('Save'),

--- a/dart/getting-started/client/lib/delete_task_alert_dialog.dart
+++ b/dart/getting-started/client/lib/delete_task_alert_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 
 import 'package:todo_list/sdk/task.dart';
 
@@ -65,22 +64,22 @@ class _DeleteTaskDialogState extends State<DeleteTaskDialog> {
         ElevatedButton(
           onPressed: () {
             Task.deleteTask(widget.token, widget.taskId).then((_) {
-              Fluttertoast.showToast(
-                  msg: "Task deleted successfully",
-                  toastLength: Toast.LENGTH_LONG,
-                  gravity: ToastGravity.BOTTOM,
-                  backgroundColor: Colors.black54,
-                  textColor: Colors.white,
-                  fontSize: 14.0);
+              // Create a snackbar to show a message to the user.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Task deleted'),
+                  backgroundColor: Colors.green,
+                ),
+              );
               Navigator.popAndPushNamed(context, "/");
             }).catchError((error) {
-              Fluttertoast.showToast(
-                  msg: "Delete failed: $error",
-                  toastLength: Toast.LENGTH_LONG,
-                  gravity: ToastGravity.SNACKBAR,
-                  backgroundColor: Colors.black54,
-                  textColor: Colors.white,
-                  fontSize: 14.0);
+              // Create a snackbar to show a message to the user.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Error deleting task'),
+                  backgroundColor: Colors.red,
+                ),
+              );
             });
           },
           style: ElevatedButton.styleFrom(

--- a/dart/getting-started/client/lib/update_task_alert_dialog.dart
+++ b/dart/getting-started/client/lib/update_task_alert_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 
 import 'package:todo_list/sdk/task.dart';
 
@@ -107,22 +106,23 @@ class _UpdateTaskAlertDialogState extends State<UpdateTaskAlertDialog> {
               url,
               "false",
             ).then((_) {
-              Fluttertoast.showToast(
-                  msg: "Task updated successfully",
-                  toastLength: Toast.LENGTH_LONG,
-                  gravity: ToastGravity.BOTTOM,
-                  backgroundColor: Colors.black54,
-                  textColor: Colors.white,
-                  fontSize: 14.0);
+              // Create a snackbar to show a message to the user.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Task updated.'),
+                  backgroundColor: Colors.green,
+                ),
+              );
+
               Navigator.popAndPushNamed(context, '/');
             }).catchError((error) {
-              Fluttertoast.showToast(
-                  msg: "Update failed: $error",
-                  toastLength: Toast.LENGTH_LONG,
-                  gravity: ToastGravity.SNACKBAR,
-                  backgroundColor: Colors.black54,
-                  textColor: Colors.white,
-                  fontSize: 14.0);
+              // Create a snackbar to show a message to the user.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Error updating task.'),
+                  backgroundColor: Colors.red,
+                ),
+              );
             });
           },
           child: const Text('Save'),

--- a/dart/getting-started/client/pubspec.lock
+++ b/dart/getting-started/client/pubspec.lock
@@ -412,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -585,10 +585,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.5.1"
   timing:
     dependency: transitive
     description:

--- a/dart/getting-started/server/pubspec.lock
+++ b/dart/getting-started/server/pubspec.lock
@@ -586,4 +586,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.6 <3.0.0"
+  dart: ">=2.19.6 <4.0.0"


### PR DESCRIPTION
The library Fluttertoast is not working out-of-the-box for Dart SDK v3.0.0 (the newest stable version of Dart).

I am removing this 3rd party dependency and using a Snackbar instead.